### PR TITLE
Add Softmax-13

### DIFF
--- a/inference/inference-core/src/commonMain/kotlin/io/kinference.core/operators/activations/Softmax.kt
+++ b/inference/inference-core/src/commonMain/kotlin/io/kinference.core/operators/activations/Softmax.kt
@@ -10,7 +10,7 @@ import io.kinference.protobuf.message.AttributeProto
 
 sealed class Softmax(name: String, info: OperatorInfo, attributes: Map<String, Attribute<Any>>, inputs: List<String>, outputs: List<String>) : Activation(name, info, attributes, inputs, outputs) {
     companion object {
-        private val DEFAULT_VERSION = VersionInfo(sinceVersion = 1, untilVersion = 14)
+        private val DEFAULT_VERSION = VersionInfo(sinceVersion = 1, untilVersion = 15)
 
         operator fun invoke(name: String, version: Int?, attributes: Map<String, Attribute<Any>>, inputs: List<String>, outputs: List<String>) = when (version ?: DEFAULT_VERSION.sinceVersion) {
             in SoftmaxVer1.VERSION.asRange() -> SoftmaxVer1(name, attributes, inputs, outputs)

--- a/inference/inference-core/src/commonMain/kotlin/io/kinference.core/operators/activations/Softmax.kt
+++ b/inference/inference-core/src/commonMain/kotlin/io/kinference.core/operators/activations/Softmax.kt
@@ -10,10 +10,11 @@ import io.kinference.protobuf.message.AttributeProto
 
 sealed class Softmax(name: String, info: OperatorInfo, attributes: Map<String, Attribute<Any>>, inputs: List<String>, outputs: List<String>) : Activation(name, info, attributes, inputs, outputs) {
     companion object {
-        private val DEFAULT_VERSION = VersionInfo(sinceVersion = 1, untilVersion = 13)
+        private val DEFAULT_VERSION = VersionInfo(sinceVersion = 1, untilVersion = 14)
 
         operator fun invoke(name: String, version: Int?, attributes: Map<String, Attribute<Any>>, inputs: List<String>, outputs: List<String>) = when (version ?: DEFAULT_VERSION.sinceVersion) {
             in SoftmaxVer1.VERSION.asRange() -> SoftmaxVer1(name, attributes, inputs, outputs)
+            in SoftmaxVer13.VERSION.asRange() -> SoftmaxVer13(name, attributes, inputs, outputs)
             else -> error("Unsupported version of Softmax operator: $version")
         }
     }
@@ -40,6 +41,30 @@ class SoftmaxVer1(name: String, attributes: Map<String, Attribute<Any>>, inputs:
 
     override suspend fun activate(input: NDArrayCore, contexts: Contexts<KIONNXData<*>>): NDArrayCore {
         input as NumberNDArrayCore
+        return input.softmax(axis)
+    }
+}
+
+class SoftmaxVer13(name: String, attributes: Map<String, Attribute<Any>>, inputs: List<String>, outputs: List<String>) : Softmax(name, INFO, attributes, inputs, outputs) {
+    companion object {
+        private val TYPE_CONSTRAINTS = FLOAT_DATA_TYPES
+
+        private val ATTRIBUTES_INFO = listOf(
+            AttributeInfo("axis", setOf(AttributeProto.AttributeType.INT), false, default = -1)
+        )
+
+        private val INPUT_INFO = listOf(IOInfo(0, TYPE_CONSTRAINTS, "input", optional = false))
+        private val OUTPUT_INFO = listOf(IOInfo(0, TYPE_CONSTRAINTS, "output", optional = false))
+
+        internal val VERSION = VersionInfo(sinceVersion = 13, untilVersion = 15)
+        private val INFO = OperatorInfo("Softmax", ATTRIBUTES_INFO, INPUT_INFO, OUTPUT_INFO, VERSION, OperatorInfo.DEFAULT_DOMAIN)
+    }
+
+    private val axis: Int by attribute { it: Number -> it.toInt() }
+
+    override suspend fun activate(input: NDArrayCore, contexts: Contexts<KIONNXData<*>>): NDArrayCore {
+        input as NumberNDArrayCore
+        // TODO: Change softmax implementation to *perform on axis* instead of converting to 2D, per Softmax-13 description of "Axis" attribute.
         return input.softmax(axis)
     }
 }


### PR DESCRIPTION
Per https://github.com/onnx/onnx/blob/main/docs/Changelog.md#Softmax-13

Context: These changes allow me to run OpenCLIP models with kinference.

Potentially unaccounted differences: 
* I am low confidence, but I think the difference with the Axis attribute in Softmax-13 vs earlier versions is actually just an implementation detail, and doesn't actually impact output/input?

* Another difference is that Softmax-13 is supposed to support BFLOAT, again low confidence, but I think that also requires no changes here?

* Lastly there is Differentiability, which doesn't matter so much because this library is for inference?